### PR TITLE
Add alternative way to get the local DB IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ psql -h [YOUR DOCKER HOST IP ADDRESS] -U postgres
 
 For example if `echo $DOCKER_HOST` returns `tcp://192.168.64.4:2376` then run `psql -h 192.168.64.4 -U postgres`
 
+If the above echo command doesn't work try:
+```sh
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' postgres-local
+```
 Create the database
 ```sql
 CREATE DATABASE callisto;
@@ -39,7 +43,7 @@ DATABASE_PASSWORD=Welcome
 ## Updating the database schema
 
 The following command will deploy the liquibase config using the docker image when run from the root of the project.
-You will need to replace the value [YOUR IP ADDRESS] with the IP address for your database. If you not running on the default port you may also need to update that in the connection string. Check that the username and passsword is also correct
+You will need to replace the value [YOUR IP ADDRESS] with the IP address for your database. If you are not running on the default port you may also need to update that in the connection string. Check that the username and password are also correct
 
 ```sh
 docker run -it --rm -v $(pwd)/db/changelog:/liquibase/changelog -v $(pwd)/db/sql:/liquibase/sql liquibase/liquibase  --url="jdbc:postgresql://[YOUR IP ADDRESS]:5432/callisto" --changeLogFile=changelog/db.changelog-main.yml --username=postgres --password=Welcome update


### PR DESCRIPTION
Add alternative way to get the local DB IP address, when `echo $DOCKER_HOST` returns nothing 