### PR TITLE
WIP: Switch to java.time.Instant

### DIFF
--- a/src/main/java/uk/gov/homeoffice/digital/sas/timecard/model/TimeEntry.java
+++ b/src/main/java/uk/gov/homeoffice/digital/sas/timecard/model/TimeEntry.java
@@ -19,8 +19,8 @@ import javax.persistence.ManyToOne;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.UUID;
 
 @Resource(path = "time-entries")
@@ -51,11 +51,11 @@ public class TimeEntry extends BaseEntity {
     @NotNull(message = "Actual start time should not be empty")
     @Column(name = "actual_start_time", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    private Date actualStartTime;
+    private Instant actualStartTime;
 
     @Column(name = "actual_end_time", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    private Date actualEndTime;
+    private Instant actualEndTime;
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
     @CreationTimestamp


### PR DESCRIPTION
**JIRA ticket:** https://collaboration.homeoffice.gov.uk/jira/browse/EAHW-2192

This PR goes in tandem with this [PR](https://github.com/UKHomeOffice/callisto-jparest/pull/11)

Use java.time.Instant instead of java.utilDate for actual start and end time attributes in Time Entry entity. This will allow the offset with UTC time to be included in the value stored in the database.