### PR TITLE
Upgrade to version 0.0.2 of callisto-jparest library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>uk.gov.homeoffice.digital.sas</groupId>
 			<artifactId>jparest</artifactId>
-			<version>0.0.1</version>
+			<version>0.0.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Upgrade to version 0.0.2 of callisto-jparest library which allows storing start and end times with time zone offset