### PR TITLE
EAHW-2208: Possible fix for timecard backend bug

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,8 @@ spring.datasource.url=jdbc:postgresql://${DATABASE_ENDPOINT}:${DATABASE_PORT}/${
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.tomcat.test-while-idle=true
+spring.datasource.tomcat.validation-query=SELECT 1
 
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.url=jdbc:postgresql://${DATABASE_ENDPOINT}:${DATABASE_PORT}/${
 spring.datasource.username=${DATABASE_USERNAME}
 spring.datasource.password=${DATABASE_PASSWORD}
 spring.datasource.driverClassName=org.postgresql.Driver
-spring.datasource.tomcat.test-while-idle=true
+spring.datasource.tomcat.test-on-borrow=true
 spring.datasource.tomcat.validation-query=SELECT 1
 
 spring.jpa.hibernate.ddl-auto=none
@@ -13,3 +13,6 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.default_schema=timecard
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.open-in-view=false
+
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
We are currently getting an error in the backend where we lose connection to the database: `HikariPool-1 - Connection is not available, request timed out after 30000ms.`

We have added a `test-on-borrow` property to test the database connection while idle to prevent timeout. The validation query `SELECT 1` guarantees that the connection has been tested before it's handed to the application.

More info on `test-on-borrow` property [here](https://tomcat.apache.org/tomcat-8.0-doc/jdbc-pool.html#Common_Attributes)