### PR TITLE
Jacoco report not running

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
       ARTIFACTORY_TOKEN:
         from_secret: artifactory_token
     commands:
-      - mvn -s ./timecard_settings.xml clean package
+      - mvn -s ./timecard_settings.xml clean verify
 
   - name: sonar
     image: maven:3.8.3-openjdk-17

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.openpojo</groupId>
+			<artifactId>openpojo</artifactId>
+			<version>0.9.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>42.4.1</version>
@@ -104,6 +110,15 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>
+						@{argLine} --add-opens java.base/java.time=ALL-UNNAMED
+					</argLine>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/src/test/java/uk/gov/homeoffice/digital/sas/timecard/model/ModelPojoTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/timecard/model/ModelPojoTest.java
@@ -1,0 +1,18 @@
+package uk.gov.homeoffice.digital.sas.timecard.model;
+
+import com.openpojo.validation.Validator;
+import com.openpojo.validation.ValidatorBuilder;
+import com.openpojo.validation.test.impl.GetterTester;
+import com.openpojo.validation.test.impl.SetterTester;
+import org.junit.jupiter.api.Test;
+
+class ModelPojoTest {
+    @Test
+    void validate() {
+        Validator validator = ValidatorBuilder.create()
+                .with(new SetterTester(),
+                        new GetterTester())
+                .build();
+        validator.validate(this.getClass().getPackageName());
+    }
+}


### PR DESCRIPTION
Jacoco report wasn't running in drone because it binds by default to `verify` phase, which is after `package` phase in [maven default lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle)

Also Added test coverage for model classes to get above the 80% minimum threshold, using [OpenPojo](https://github.com/OpenPojo/openpojo) library