### PR TITLE
EAHW 2589: update branch ingress

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     kubernetes.io/ingress.class: "nginx-internal"
     kubernetes.io/backend-protocol: "HTTPS"
     ingress.kubernetes.io/enable-cors: "true"
-    ingress.kubernetes.io/cors-allow-origin: "https://web.dev.callisto-notprod.homeoffice.gov.uk"
+    ingress.kubernetes.io/cors-allow-origin: "https://*.dev.callisto-notprod.homeoffice.gov.uk"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Update cors-allow-origin in ingress to permit branch UI deploy url.