### PR TITLE
Add values to promote kafka init containers to prod

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,9 +43,7 @@ spec:
             - name: timecard-restapi-script-volume
               mountPath: /scripts
           env: {{ toYaml .Values.env.database | nindent 12 }}
-          {{- if .Values.env.kafka }}
             {{ toYaml .Values.env.kafka | nindent 12 }}
-          {{ end }}
       initContainers:
         - name: timecard-database
           image: {{ .Values.image.repo }}callisto-timecard-database:{{ .Values.image.tag }}
@@ -58,7 +56,6 @@ spec:
             - "--changeLogFile=changelog/db.changelog-main.yml"
             - "--liquibaseSchemaName=timecard"
             - "update"
-        {{- if .Values.env.kafka }}
         - name: timecard-create-keystore
           image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/callisto/awscli-java-openssl:latest
           imagePullPolicy: Always
@@ -82,7 +79,6 @@ spec:
               mountPath: /scripts
             - name: keystore-volume
               mountPath: /timecard-restapi-keystore
-        {{ end }}
       volumes:
       - name: timecard-restapi-script-volume
         configMap:

--- a/helm/values/dev-values.yaml
+++ b/helm/values/dev-values.yaml
@@ -61,7 +61,7 @@ env:
     - name: TIMECARD_KEYSTORE_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: callisto-dev-keystore-password
+          name: callisto-dev-timecard-keystore
           key: password
     - name: TIMECARD_TOPIC
       value: callisto-timecard-timeentries

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -37,3 +37,31 @@ env:
         secretKeyRef:
           name: callisto-prod-1
           key: port
+  kafka:
+    - name: BOOTSTRAP_SERVER
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-bootstrap
+          key: bootstrap_server1
+    - name: AWS_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_access_keys
+    - name: AWS_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_secret_keys
+    - name: AWS_CERTIFICATE_AUTHORITY_ARN
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_arn
+    - name: TIMECARD_KEYSTORE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-keystore-password
+          key: password
+    - name: TIMECARD_TOPIC
+      value: callisto-timecard-timeentries

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -61,7 +61,7 @@ env:
     - name: TIMECARD_KEYSTORE_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: callisto-prod-keystore-password
+          name: callisto-prod-timecard-keystore
           key: password
     - name: TIMECARD_TOPIC
       value: callisto-timecard-timeentries

--- a/helm/values/test-values.yaml
+++ b/helm/values/test-values.yaml
@@ -61,7 +61,7 @@ env:
     - name: TIMECARD_KEYSTORE_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: callisto-test-keystore-password
+          name: callisto-test-timecard-keystore
           key: password
     - name: TIMECARD_TOPIC
       value: callisto-timecard-timeentries


### PR DESCRIPTION
This PR adds the values for the prod environment. Allowing us to run the kafka init containers in the env
Have also updated the naming convention for keystore secrets