### PR TITLE
Update timecard to use group permissions for balance-calculator consumer

### DIFF
--- a/helm/kafka/scripts/create-topic.sh
+++ b/helm/kafka/scripts/create-topic.sh
@@ -10,8 +10,6 @@ set -e
 # get_current_acl timecard literal
 get_current_acl() {
 
-    local topic=$1
-    local type=$2
     local acls
 
     # Call the kafka-acl script with relevant arguments and grep only the lines
@@ -35,7 +33,7 @@ set_permissions() {
     echo Applying desired permissions for "${parameters[@]}"
 
     # get the current ACL for given topic and pattern type
-    local current_acl=($(get_current_acl $topic $type))
+    local current_acl=($(get_current_acl "${parameters[@]}"))
 
     # Iterate the current ACL to see if each existing permission
     # is still required. Remove any that are not desired

--- a/helm/kafka/scripts/create-topic.sh
+++ b/helm/kafka/scripts/create-topic.sh
@@ -112,7 +112,7 @@ function apply_permissions() {
         then
             # if permissions have already been specified for a previous topic
             # apply them.
-            if [ -n "$commandd_args" ]
+            if [ -n "$command_args" ]
             then
                 IFS=$'\n'
                 set_permissions "${command_args[@]}" "${permissions[*]/%/$'\n'}"

--- a/helm/kafka/scripts/create-topic.sh
+++ b/helm/kafka/scripts/create-topic.sh
@@ -18,8 +18,7 @@ get_current_acl() {
     # form the output with the principals. Then use sed to strip out everything
     # but the required values leaving us with a space delimited list of existing
     # permissions
-    IFS=$'\n' acls=( $(kafka-acls.sh --bootstrap-server $bootstrap_server --command-config $properties_file --list --topic $topic --resource-pattern-type $type | grep -o -e '(principal.*)' | sed -E 's/.*principal=(.*), host=\*, operation=(.*), permissionType=(.*)\)/\1 \2 \3/') )
-
+    IFS=$'\n' acls=( $(kafka-acls.sh --bootstrap-server $kafka_host --command-config $properties_file --list "${@}" | grep -o -e '(principal.*)' | sed -E 's/.*principal=(.*), host=\*, operation=(.*), permissionType=(.*)\)/\1 \2 \3/') )
     echo "${acls[*]/%/$'\n'}"
 
 }
@@ -28,13 +27,12 @@ get_current_acl() {
 # to the specified ACL
 set_permissions() {
 
-    local topic=$1
-    local type=$2
-    local desired_permissions=($3)
+    local parameters=("${@:1:$#-1}")
+    local desired_permissions=(${*: -1:1})
     local existing_permissions=()
     local set details principal operation permission
 
-    echo Applying desired permissions for $topic $type
+    echo Applying desired permissions for "${parameters[@]}"
 
     # get the current ACL for given topic and pattern type
     local current_acl=($(get_current_acl $topic $type))
@@ -55,7 +53,7 @@ set_permissions() {
             echo Removing: ${principal} ${operation} ${permission}
             kafka-acls.sh --bootstrap-server $bootstrap_server \
                 --command-config $properties_file \
-                --topic $topic --resource-pattern-type $type \
+                "${parameters[@]}" \
                 --remove --force \
                 --${permission,,}-principal $principal --operation $operation \
                 > /dev/null
@@ -83,7 +81,7 @@ set_permissions() {
             echo Adding: ${principal} ${operation} ${permission}
             kafka-acls.sh --bootstrap-server $bootstrap_server\
                 --command-config $properties_file \
-                --topic $topic --resource-pattern-type $type \
+                "${parameters[@]}" \
                 --add --force \
                 --${permission,,}-principal $principal --operation $operation \
                 > /dev/null
@@ -96,7 +94,7 @@ set_permissions() {
 function apply_permissions() {
 
     local acl_config line
-    local details topic pattern_type
+    local details command_args topic pattern_type
     local permissions principal operation permission
 
     # read through the contents of the permissions file and
@@ -110,17 +108,18 @@ function apply_permissions() {
         details=($line)
 
         # if first argument is --topic assume a new list of permissions are being specified
-        if [ "${details[0]}" = "--topic" ]
+        if [ "${details[0]}" =~ "--" ] ]
         then
             # if permissions have already been specified for a previous topic
             # apply them.
-            if [ -n "$topic" ]
+            if [ -n "$commandd_args" ]
             then
                 IFS=$'\n'
-                set_permissions $topic $pattern_type "${permissions[*]/%/$'\n'}"
+                set_permissions "${command_args[@]}" "${permissions[*]/%/$'\n'}"
                 unset IFS
             fi
             # Reset the variables
+            command_args=("${details[@]}")
             topic=${details[1]}
             pattern_type=${details[3]}
             permissions=()
@@ -139,10 +138,10 @@ function apply_permissions() {
 
     # The end of the file has been reached. If a topic
     # was set apply the permissions.
-    if [ -n "$topic" ]
+    if [ -n "$command_args" ]
     then
         IFS=$'\n'
-        set_permissions $topic $pattern_type "${permissions[*]/%/$'\n'}"
+        set_permissions "${command_args[@]}" "${permissions[*]/%/$'\n'}"
         unset IFS
     fi
 }

--- a/helm/kafka/scripts/create-topic.sh
+++ b/helm/kafka/scripts/create-topic.sh
@@ -108,7 +108,7 @@ function apply_permissions() {
         details=($line)
 
         # if first argument is --topic assume a new list of permissions are being specified
-        if [ "${details[0]}" =~ "--" ] ]
+        if [[ "${details[0]}" =~ "--" ]]
         then
             # if permissions have already been specified for a previous topic
             # apply them.

--- a/helm/kafka/scripts/permissions.txt
+++ b/helm/kafka/scripts/permissions.txt
@@ -1,7 +1,7 @@
 # Timecard prefix permissions
 --topic timecard --resource-pattern-type prefixed
-User:timecard-restapi     Write       Allow
-User:timecard-restapi     Describe    Allow
+User:timecard-restapi-producer     Write       Allow
+User:timecard-restapi-producer     Describe    Allow
 User:balance-calculator   Read        Allow
 
 --group console-consumer --resource-pattern-type prefixed

--- a/helm/kafka/scripts/permissions.txt
+++ b/helm/kafka/scripts/permissions.txt
@@ -1,4 +1,8 @@
 # Timecard prefix permissions
 --topic timecard --resource-pattern-type prefixed
-User:timecard-restapi-producer     Write       Allow
-User:timecard-restapi-producer     Describe    Allow
+User:timecard-restapi     Write       Allow
+User:timecard-restapi     Describe    Allow
+User:balance-calculator   Read        Allow
+
+--group console-consumer --resource-pattern-type prefixed
+User:balance-calculator      All            Allow


### PR DESCRIPTION
This pr updates the scripts that manage the ACLS for callisto-timecard-timeentries topic. It now no longer parses the "instruction" line in the permissions.txt file but just passes through the options to the kafka command called. This allows us to use the exact same mechanism for managing ACLs for topics to manage ACLs for groups

The balance calculator certificate common name has also been added to the permissions.txt so the relevant permissions can be applied.