### PR TITLE
Stop deployments to Dev and Test Environments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -335,12 +335,13 @@ depends_on:
   - callisto-timecard-restapi-dev-deploy
 
 trigger:
-  exclude:
-    - push
-    - pull_request
-    - tag
-    - promote
-    - rollback
+  event:
+    exclude:
+      - push
+      - pull_request
+      - tag
+      - promote
+      - rollback
   #to reinstate test deploy on pull requests change trigger to
   #trigger:
   # event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -244,8 +244,16 @@ depends_on:
 
 trigger:
   event:
+    exclude:
+    - push
     - pull_request
-
+    - tag
+    - promote
+    - rollback
+#to reinstate branch deploys on pull requests change trigger to
+#trigger:
+# event:
+#   - pull_request
 steps:
   - name: branch_deploy
     image: pelotech/drone-helm3
@@ -281,10 +289,17 @@ depends_on:
 
 trigger:
   event:
-    include:
-      - push
     exclude:
+      - push
+      - pull_request
+      - tag
       - promote
+      - rollback
+#to reinstate dev deploy on pull requests change trigger to
+#trigger:
+# event:
+#    include:
+#      - push
   branch:
     - main
 
@@ -320,10 +335,17 @@ depends_on:
   - callisto-timecard-restapi-dev-deploy
 
 trigger:
-  event:
-    - push
   exclude:
+    - push
+    - pull_request
+    - tag
     - promote
+    - rollback
+  #to reinstate test deploy on pull requests change trigger to
+  #trigger:
+  # event:
+  #    include:
+  #      - push
   branch:
     - main
 


### PR DESCRIPTION
This PR changes drone triggers to exclude all scenarios for deplyoments to dev and test environments